### PR TITLE
Add chatbot crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Open <http://localhost:3000/> in your browser.
 ## Completed Chapters
 - [x] Warmup
 - [x] Async and Await
+- [x] Joining Futures

--- a/crates/chatbot/Cargo.toml
+++ b/crates/chatbot/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "chatbot"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = { version = "0.8.5", features = ["small_rng"] }
+tokio = { workspace = true, features = ["time"] }

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -1,0 +1,30 @@
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::{cell::RefCell, time::Duration};
+
+thread_local! {
+    static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_entropy());
+}
+
+/// Seeds the thread-local RNG used by [`gen_random_number`].
+pub fn seed_rng(seed: u64) {
+    RNG.with(|rng| *rng.borrow_mut() = SmallRng::seed_from_u64(seed));
+}
+
+/// Generates a random `usize`.
+///
+/// Warning: may take a few seconds!
+pub async fn gen_random_number() -> usize {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    RNG.with(|rng| rng.borrow_mut().gen())
+}
+
+/// Generates a list of possible responses given the current chat.
+///
+/// Warning: may take a few seconds!
+pub async fn query_chat(_messages: &[String]) -> Vec<String> {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    vec![
+        "And how does that make you feel?".to_string(),
+        "Interesting! Go on...".to_string(),
+    ]
+}

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -21,10 +21,11 @@ pub async fn gen_random_number() -> usize {
 /// Generates a list of possible responses given the current chat.
 ///
 /// Warning: may take a few seconds!
-pub async fn query_chat(_messages: &[String]) -> Vec<String> {
+pub async fn query_chat(messages: &[String]) -> Vec<String> {
     tokio::time::sleep(Duration::from_secs(2)).await;
+    let most_recent = messages.last().unwrap();
     vec![
-        "And how does that make you feel?".to_string(),
-        "Interesting! Go on...".to_string(),
+        format!("\"{most_recent}\"? And how does that make you feel?"),
+        format!("\"{most_recent}\"! Interesting! Go on..."),
     ]
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,3 +8,4 @@ miniserve = { path = "../miniserve" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 tokio = { workspace = true, features = ["full"] }
+chatbot = { path = "../chatbot" }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -20,7 +20,6 @@ async fn chat(req: Request) -> Response {
             } else {
                 None
             }).collect::<Vec<String>>();
-            println!("{messages_vec:?}");
             let responses = chatbot::query_chat(&messages_vec);
             let random_number = chatbot::gen_random_number();
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,5 +1,6 @@
 use miniserve::{http, Content, Request, Response};
 use serde_json::Value;
+use tokio::join;
 
 async fn index(_req: Request) -> Response {
     let content = include_str!("../index.html").to_string();
@@ -14,9 +15,18 @@ async fn chat(req: Request) -> Response {
         };
 
         if let Value::Array(messages) = &mut json_data["messages"] {
-            messages.push(Value::String(String::from("Fixed response")));
+            let messages_vec = messages.iter().flat_map(|message| if let Value::String(msg) = message {
+                Some(msg.clone())
+            } else {
+                None
+            }).collect::<Vec<String>>();
+            println!("{messages_vec:?}");
+            let responses = chatbot::query_chat(&messages_vec);
+            let random_number = chatbot::gen_random_number();
 
-            println!("{json_data}");
+            let (responses,random_number) = join!(responses, random_number);
+
+            messages.push(Value::String(responses[random_number % responses.len()].clone()));
 
             Ok(Content::Json(json_data.to_string()))
         } else {


### PR DESCRIPTION
This PR adds a new crate, `chatbot`, which provides functions for running an "intelligent" chatbot to respond to the user's queries. Those functions are:
* `chatbot::gen_random_number`: creates a random number from 0 to the maximum `usize`.
* `chatbot::query_chat`: given a set of input messages, queries the model for a vector of generated responses.

Resolves #6. (Don't merge until you've added your solution!)
